### PR TITLE
small fixes to enable windows compilation on mingw

### DIFF
--- a/include/ADOConnection.h
+++ b/include/ADOConnection.h
@@ -11,7 +11,7 @@ Version History
 #ifndef ADO_CONNECTION_H
 #define ADO_CONNECTION_H
 
-#ifdef _WIN32
+#ifdef USE_ADO
 
 #import "msado15.dll"  \
     rename( "EOF", "AdoNSEOF" )

--- a/src/ADOConnection.cpp
+++ b/src/ADOConnection.cpp
@@ -10,7 +10,7 @@ Version History
 ******************************************************************************/
 #include "ADOConnection.h"
 
-#ifdef _WIN32
+#if USE_ADO
 #include <string>
 #include <iostream>
 using namespace std;

--- a/src/Utility.cpp
+++ b/src/Utility.cpp
@@ -44,6 +44,7 @@ Version History
 
 #ifdef _WIN32
   #include <string>
+  #include "profileapi.h"
   using namespace std;
 #endif
 

--- a/src/VARS_Algorithm.cpp
+++ b/src/VARS_Algorithm.cpp
@@ -20,7 +20,7 @@ Version History
 #include "ParameterGroup.h"
 #include "ObjectiveFunction.h"
 
-#ifdef WIN32
+#ifdef _WIN32
   #include <Windows.h>
 #else
   #include <dlfcn.h>


### PR DESCRIPTION
there are a few smaller issues when compiling with MinGW, these are mostly bugs, e.g., a missing header. Worse is that ACCESS file support relies on an dodgy #import statement that is a microsoft extension. We therefore changed this by adding USE_ADO as a new switch, replacing the old use of checking whether _WIN32 is defined. As a result, ADO is not supported on windows with any compiler that is not msvc.